### PR TITLE
Fix hoverRect bug

### DIFF
--- a/app/scripts/directives/snapsvg.js
+++ b/app/scripts/directives/snapsvg.js
@@ -147,7 +147,7 @@ angular.module('cardkitApp')
             }
 
             // Elements, which have `draggablex = false`, can be unhovered by moving horizontally the cursor during dragging.
-            // It is also true that `draggabley = false` and moving the cursor vertically/
+            // It is also true that `draggabley = false` and moving the cursor vertically
             // At the moment, the hoverRect is not removed correctly. This prevents unexpected proliferations of hoverRect
             if(this.unhoveringDuringDragging){
               this.hoverRect.remove();

--- a/app/scripts/directives/snapsvg.js
+++ b/app/scripts/directives/snapsvg.js
@@ -90,6 +90,7 @@ angular.module('cardkitApp')
           var dragStart = function () {
             this.data('ot', this.transform().local);
             s.elementDragging = true;
+            s.elementUnhoveringDuringDragging = false;
           };
 
           var dragMoveAll = function(dx, dy) {
@@ -144,6 +145,14 @@ angular.module('cardkitApp')
                 fill: 'rgba(0, 0, 0, 0.05)'
               });
               this.before(this.hoverRect);
+            }
+
+            // Elements, which have `draggablex = false`, can be unhovered by moving horizontally the cursor during dragging.
+            // It is also true that `draggabley = false` and moving the cursor vertically/
+            // At the moment, the hoverRect is not removed correctly. This prevents unexpected proliferations of hoverRect
+            if(s.elementUnhoveringDuringDragging){
+              this.hoverRect.remove();
+              s.elementUnhoveringDuringDragging = false;
             }
           };
         });
@@ -398,6 +407,9 @@ angular.module('cardkitApp')
               }, function(e) {
                 if(!s.elementDragging && element.showHoverArea && this.hoverRect) {
                   this.hoverRect.remove();
+                }
+                if( element.showHoverArea && this.hoverRect) {
+                  s.elementUnhoveringDuringDragging = true;
                 }
               });
             }

--- a/app/scripts/directives/snapsvg.js
+++ b/app/scripts/directives/snapsvg.js
@@ -90,7 +90,6 @@ angular.module('cardkitApp')
           var dragStart = function () {
             this.data('ot', this.transform().local);
             s.elementDragging = true;
-            s.elementUnhoveringDuringDragging = false;
           };
 
           var dragMoveAll = function(dx, dy) {
@@ -150,9 +149,9 @@ angular.module('cardkitApp')
             // Elements, which have `draggablex = false`, can be unhovered by moving horizontally the cursor during dragging.
             // It is also true that `draggabley = false` and moving the cursor vertically/
             // At the moment, the hoverRect is not removed correctly. This prevents unexpected proliferations of hoverRect
-            if(s.elementUnhoveringDuringDragging){
+            if(this.unhoveringDuringDragging){
               this.hoverRect.remove();
-              s.elementUnhoveringDuringDragging = false;
+              this.unhoveringDuringDragging = false;
             }
           };
         });
@@ -404,12 +403,15 @@ angular.module('cardkitApp')
                   });
                   this.before(this.hoverRect);
                 }
+                if(s.elementDragging && element.showHoverArea) {
+                  this.unhoveringDuringDragging = false;
+                }
               }, function(e) {
                 if(!s.elementDragging && element.showHoverArea && this.hoverRect) {
                   this.hoverRect.remove();
                 }
-                if( element.showHoverArea && this.hoverRect) {
-                  s.elementUnhoveringDuringDragging = true;
+                if(s.elementDragging && element.showHoverArea && this.hoverRect) {
+                  this.unhoveringDuringDragging = true;
                 }
               });
             }


### PR DESCRIPTION
related #45 

#### issue
hoverRect is unexpectedly not removed, when the element is un-hovered during you are dragging it.

#### cause
In `snapsvg.js`, Unhover events associated with hoverRect are not fires as long as `s.elementDragging = true`

#### This pull request...
- add a bool property `unhoveringDuringDragging`
- on `dragEnd`, check `unhoveringDuringDragging` and remove hoverRect if necessary

Thanks for reading!